### PR TITLE
Add search-forward and skip-chars-forward functions

### DIFF
--- a/rust/element/src/cursor.rs
+++ b/rust/element/src/cursor.rs
@@ -364,72 +364,84 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Search forward from point to str. Sets point to the end of the
+    /// occurence found and returns point. bound is a position in the
+    /// buffer. The match found must not end after that position. If
+    /// None then search to end of the buffer. If count is specified,
+    /// find the countth occurence. If countth occurence is not found
+    /// None is returned. If count is not provided then 1 is used as
+    /// count. Note that searching backward is not supported like it
+    /// is in the elisp equivalent.
     pub fn search_forward(&mut self, str: &str,
                           bound: Option<usize>,
-                          count: Option<i64>) -> Option<usize> {
-
-        let mut search_backward = false;
-        let count: i64 = match count {
-            Some(count) => {
-                if count < 0 {
-                    search_backward = true;
-                    (count * -1) - 1
-                } else {
-                    count - 1
-                }
-            },
-            _ => 0
+                          count: Option<usize>) -> Option<usize> {
+        let count = match count {
+            Some(count) => count,
+            _ => 1
         };
 
         let bound = match bound {
             Some(bound) => bound,
-            _ => {
-                if search_backward {
-                    0
-                } else {
-                    self.data.len()
-                }
-            }
+            _ => self.data.len()
         };
 
-        println!("bound: {}", bound);
         let pos = self.pos();
-        if search_backward {
-            if bound > pos {
-                return None;
-            }
-            let matches: Vec<_> = self.data[bound..self.pos()].match_indices(str).collect();
-        } else {
-            if bound < pos {
-                return None;
-            }
-            let mut iter = self.data[pos..].match_indices(str);
-            let mut i = 0;
-            let mut prev_match: Option<usize> = None;
-            loop {
-                match iter.next() { // next index of beginning text
-                    Some(result) => {
-                        println!("count: {}", count);
-                        if result.0 + pos > bound { // bound check
-                            return prev_match;
-                        }
-                        if count == i {             // count check
-                            println!("bingo {} {} {}", result.0, pos, str.len());
-                            self.set(result.0 + pos + str.len());
-                            return Some(result.0 + pos + str.len());
-                        }
-                        i += 1;
-                        prev_match = Some(result.0);
-                    },
-                    None => { // TODO fix
-                        return None
+        if bound < pos {
+            return None;
+        }
+
+        let mut iter = self.data[pos..].match_indices(str);
+        let mut i = 1;
+        loop {
+            match iter.next() {
+                Some(result) => {
+                    if result.0 + pos + str.len() > bound {
+                        return None;
                     }
+
+                    if count == i {
+                        self.set(result.0 + pos + str.len());
+                        return Some(result.0 + pos + str.len());
+                    }
+
+                    i += 1;
+                },
+                None => {
+                    return None
                 }
             }
         }
-        None
+    }
+
+    /// Moves point forward, stopping before a char not in str, or at position limit.
+    pub fn skip_chars_forward(&mut self, str: &str, limit: Option<usize>) -> usize {
+        let pos = self.pos();
+        let limit = match limit {
+            Some(lim) => lim,
+            _ => self.data.len()
+        };
+        
+        if pos >= limit {
+            return 0;
+        }
+
+        let mut count = 0;
+        while let Some(c) = self.get_next_char() {
+            if !str.contains(c) {
+                self.get_prev_char();
+                return count;
+            }
+            if count + pos > limit {
+                self.get_prev_char();
+                return count;
+            }
+            count += 1;
+        }
+        count
     }
 }
+
+
 
 /// Given the inital byte of a UTF-8 codepoint, returns the number of
 /// bytes required to represent the codepoint.
@@ -670,5 +682,20 @@ mod test {
         assert_eq!(cursor.search_forward("two", None, Some(4)), Some(43));
         assert_eq!(cursor.pos(), 43);
         assert_eq!(cursor.search_forward("aba", Some(10), None), None); // bound is before current pos
+        assert_eq!(cursor.pos(), 43);
+        assert_eq!(cursor.search_forward("aba", Some(10000), Some(2)), Some(62));
+        cursor.set(0);
+        assert_eq!(cursor.search_forward("aba", Some(10000), Some(6)), None);
+    }
+
+    #[test]
+    fn skip_chars_forward() {
+        let str = "  k\t **hello";
+        let mut cursor = Cursor::new(&str, 0);
+        assert_eq!(cursor.skip_chars_forward(" ", None), 2);
+        assert_eq!(cursor.pos(), 2);
+        assert_eq!(cursor.skip_chars_forward(" k\t", None), 3);
+        cursor.set(0);
+        assert_eq!(cursor.skip_chars_forward("* k\t", Some(2)), 3);
     }
 }


### PR DESCRIPTION
There are a good amount of built in functions we will need to implement most, if not all of the parser functions. Here is my crack at adding these two. `search-forward` is weird because it supports searching backward but I didn't bother implementing that here. I probably should add some more tests and tidy up but thought I would open a PR and maybe get some feedback first.