### PR TITLE
Add the `testing` crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = [ "element" ]
+members = [ "element", "testing" ]

--- a/rust/element/Cargo.toml
+++ b/rust/element/Cargo.toml
@@ -12,3 +12,7 @@ regex = "1"
 lazy_static = "^1.3.0"
 strum = "^0.15.0"
 strum_macros = "^0.15.0"
+
+[dev-dependencies]
+testing = { path = "../testing" }
+

--- a/rust/testing/Cargo.toml
+++ b/rust/testing/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "testing"
+version = "0.1.0"
+authors = ["Asa Zeren <asaizeren@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/testing/src/lib.rs
+++ b/rust/testing/src/lib.rs
@@ -1,0 +1,9 @@
+//! # Testing
+//!
+//! This module should contain test helpers. Most of these are going
+//! to be found in [`org-test.el`]. Note that this is not a complete
+//! port of `org-test.el`, as the interactive components are out of
+//! scope for this project, being a part of the org-emacs integration,
+//! not a fundumental part of org.
+//!
+//! [`org-test.el`]: https://code.orgmode.org/bzg/org-mode/src/master/testing/org-test.el


### PR DESCRIPTION
There are a number of important subroutines for testing a number of org
features, not just org-element, so these have to live in a different crate.

This crate is called `testing` as (a) it is a reasonable name, and (b) it is
the name of the corrosponding folder in the org source.