### PR TITLE
Change `parent` of `SyntaxNode` to `RefCell` from `Cell`

### DIFF
--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -63,7 +63,7 @@ pub struct Interval {
 
 pub struct SyntaxNode<'a> {
     /// Parent node.
-    pub parent: Cell<Option<WeakHandle<'a>>>,
+    pub parent: RefCell<Option<WeakHandle<'a>>>,
     /// Child nodes of this node.
     pub children: RefCell<Vec<Handle<'a>>>,
 
@@ -89,7 +89,7 @@ pub struct SyntaxNode<'a> {
 impl<'a> SyntaxNode<'a> {
     pub fn create_root() -> SyntaxNode<'a> {
         SyntaxNode {
-            parent: Cell::new(None),
+            parent: RefCell::new(None),
             children: RefCell::new(vec![]),
             data: Syntax::OrgData,
             location: Interval { start: 0, end: 0 },


### PR DESCRIPTION
Since `Weak` is not `Copy` (and therefore `Option<WeakHandle>>` is not `Copy`) it shouldn't be put into a `Cell`, only a `RefCell`. In a `Cell`, there is no way to access the content of the parent.