### PR TITLE
`SyntaxNode::append_child`

### DIFF
--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -100,7 +100,7 @@ impl<'a> SyntaxNode<'a> {
     }
 
     /// Appends a child to the node, setting the child's parent correctly.
-    pub fn append_child(self: Handle<'a>, child: Handle<'a>) {
+    pub fn append_child(self: &Handle<'a>, child: Handle<'a>) {
         *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
         self.children.borrow_mut().push(child);
     }

--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -98,6 +98,13 @@ impl<'a> SyntaxNode<'a> {
             affiliated: None,
         }
     }
+
+    /// Appends a child to the node, setting the child's parent correctly.
+    pub fn append_child(self: Handle<'a>, child: Handle<'a>) {
+        *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
+        self.children.borrow_mut().push(child);
+    }
+    
 }
 
 /// Complete list of syntax entities
@@ -112,6 +119,13 @@ pub enum Syntax<'a> {
 
     /// Greater element
     CenterBlock,
+
+
+
+
+
+
+
 
     /// Element
     Clock(Box<ClockData<'a>>),
@@ -879,5 +893,4 @@ mod test {
         assert!(closure_test(br, |that| bold.can_contain(that)));
         assert!(!closure_test(verse, |that| bold.can_contain(that)));
     }
-
 }


### PR DESCRIPTION
Adds a convient method to add a child to a syntax node. This should improve the
readability of code that constructs trees of `SyntaxNode`s.