### PR TITLE
 Implement `SyntaxNode::nodes`

### DIFF
--- a/rust/element/src/babel.rs
+++ b/rust/element/src/babel.rs
@@ -22,6 +22,7 @@ lazy_static! {
     pub static ref REGEX_BABEL_CALL: Regex = Regex::new(r"\+CALL:").unwrap();
 }
 
+#[derive(Debug)]
 pub struct BabelCallData<'a> {
     /// Name of code block being called (string).
     pub call: &'a str,

--- a/rust/element/src/blocks.rs
+++ b/rust/element/src/blocks.rs
@@ -35,6 +35,7 @@ lazy_static! {
 }
 
 /// Greater element
+#[derive(Debug)]
 pub struct DynamicBlockData<'a> {
     /// Block's parameters (string).
     arguments: &'a str,
@@ -46,11 +47,13 @@ pub struct DynamicBlockData<'a> {
     drawer_name: &'a str,
 }
 
+#[derive(Debug)]
 pub struct CommentBlockData<'a> {
     /// Comments, without block's boundaries (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct ExampleBlockData<'a> {
     /// Format string used to write labels in current block,
     /// if different from org_coderef_label_format (string or nil).
@@ -89,6 +92,7 @@ pub struct ExampleBlockData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct ExportBlockData<'a> {
     ///Related back_end's name (string).
     type_s: &'a str,
@@ -97,6 +101,7 @@ pub struct ExportBlockData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct SpecialBlockData<'a> {
     /// Block's name (string).
     type_s: &'a str,
@@ -104,6 +109,7 @@ pub struct SpecialBlockData<'a> {
     raw_value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct SrcBlockData<'a> {
     /// Format string used to write labels in current block,
     /// if different from org_coderef_label_format (string or nil).

--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -100,7 +100,7 @@ impl<'a> SyntaxNode<'a> {
     }
 
     /// Appends a child to the node, setting the child's parent correctly.
-    pub fn append_child(self: Handle<'a>, child: Handle<'a>) {
+    pub fn append_child(self: &Handle<'a>, child: Handle<'a>) {
         *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
         self.children.borrow_mut().push(child);
     }

--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -104,7 +104,12 @@ impl<'a> SyntaxNode<'a> {
         *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
         self.children.borrow_mut().push(child);
     }
-    
+
+    /// Creates an iterator over the node and its direct and indirect
+    /// children, in pre-order.
+    pub fn nodes(self: &Handle<'a>) -> Nodes<'a> {
+        Nodes::new(self.clone())
+    }
 }
 
 /// Complete list of syntax entities
@@ -119,13 +124,6 @@ pub enum Syntax<'a> {
 
     /// Greater element
     CenterBlock,
-
-
-
-
-
-
-
 
     /// Element
     Clock(Box<ClockData<'a>>),
@@ -898,8 +896,67 @@ pub struct VerbatimData<'a> {
     value: &'a str,
 }
 
-mod test {
+/// A pre-order traversal of a [`SyntaxNode`].
+pub struct Nodes<'a> {
+    index_stack: Vec<usize>,
+    current_node: Handle<'a>,
+}
 
+impl<'a> Nodes<'a> {
+    fn new(handle: Handle<'a>) -> Nodes<'a> {
+        Nodes {
+            index_stack: vec![0],
+            current_node: handle,
+        }
+    }
+}
+
+impl<'a> Iterator for Nodes<'a> {
+    type Item = Handle<'a>;
+
+    fn next(&mut self) -> Option<Handle<'a>> {
+        dbg!(&self.index_stack);
+        let node = self.current_node.clone();
+
+        if self.index_stack.is_empty() {
+            return None;
+        }
+
+        while self.current_node.children.borrow().len() <= *self.index_stack.last().unwrap() {
+            self.index_stack.pop();
+            if self.index_stack.is_empty() {
+                return Some(node);
+            }
+            let next = self
+                .current_node
+                .parent
+                .borrow()
+                .as_ref()
+                .expect("An iterated parse tree was mutated while an iterator was alive.")
+                .upgrade()
+                .expect(
+                    "An iterated parse tree had its parents deallocated while an iterator is alive",
+                )
+                .clone();
+            self.current_node = next;
+        }
+
+        let top_idx_idx = self.index_stack.len() - 1;
+        let next = self.current_node.children.borrow()[self.index_stack[top_idx_idx]].clone();
+        self.index_stack[top_idx_idx] += 1;
+        self.index_stack.push(0);
+        self.current_node = next;
+
+        dbg!(&self.index_stack);
+        dbg!(&node);
+        Some(node)
+    }
+}
+
+mod test {
+    use std::rc::Rc;
+
+    use crate::data::SyntaxNode;
     use crate::data::SyntaxT;
 
     #[test]
@@ -918,5 +975,61 @@ mod test {
         assert!(bold.can_contain(SyntaxT::LineBreak));
         assert!(closure_test(br, |that| bold.can_contain(that)));
         assert!(!closure_test(verse, |that| bold.can_contain(that)));
+    }
+
+    #[test]
+    fn nodes_iter_with_a_single_element_returns_that_element() {
+        let node = Rc::new(SyntaxNode::create_root());
+        let out_nodes = node.clone().nodes().collect::<Vec<_>>();
+        assert_eq!(out_nodes.len(), 1);
+        assert!(Rc::ptr_eq(&out_nodes[0], &node));
+    }
+
+    #[test]
+    fn nodes_iter_with_several_children_return_all() {
+        let parent = Rc::new(SyntaxNode::create_root());
+        const NUM_CHILDREN: usize = 4;
+        let children = std::iter::repeat(())
+            .take(NUM_CHILDREN)
+            .map(|_| Rc::new(SyntaxNode::create_root()))
+            .collect::<Vec<_>>();
+        for child in &children {
+            parent.append_child(child.clone());
+        }
+
+        let results = parent.nodes().collect::<Vec<_>>();
+        dbg!(&results);
+
+        assert_eq!(results.len(), NUM_CHILDREN + 1);
+        assert!(Rc::ptr_eq(&parent, &results[0]));
+
+        for (idx, child) in children.iter().enumerate() {
+            assert!(
+                Rc::ptr_eq(&child, &results[idx + 1]),
+                "Pointer did not match (idx = {})",
+                idx + 1
+            );
+        }
+    }
+
+    #[test]
+    fn nodes_iter_with_several_layers_return_all() {
+        const LEVELS: usize = 4;
+        let nodes = std::iter::repeat(())
+            .take(LEVELS)
+            .map(|_| Rc::new(SyntaxNode::create_root()))
+            .collect::<Vec<_>>();
+        for (idx, node) in nodes.iter().enumerate() {
+            if idx == 0 { continue }
+            nodes[idx-1].append_child(node.clone());
+        }
+
+        let results = nodes[0].nodes().collect::<Vec<_>>();
+        
+        assert_eq!(results.len(), nodes.len());
+
+        for (result, input) in results.iter().zip(nodes.iter()) {
+            assert!(Rc::ptr_eq(result, input));
+        }
     }
 }

--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -51,7 +51,7 @@ pub type Handle<'a> = Rc<SyntaxNode<'a>>;
 /// Weak reference to a DOM node, used for parent pointers.
 pub type WeakHandle<'a> = Weak<SyntaxNode<'a>>;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Interval {
     pub start: usize,
     pub end: usize,
@@ -60,7 +60,7 @@ pub struct Interval {
 /// ParseTree node.
 /// https://orgmode.org/worg/dev/org-element-api.html#attributes
 /// Should be bound to the underlying rope's lifetime
-
+#[derive(Debug)]
 pub struct SyntaxNode<'a> {
     /// Parent node.
     pub parent: RefCell<Option<WeakHandle<'a>>>,
@@ -101,7 +101,7 @@ impl<'a> SyntaxNode<'a> {
 }
 
 /// Complete list of syntax entities
-#[derive(EnumDiscriminants)]
+#[derive(Debug, EnumDiscriminants)]
 #[strum_discriminants(name(SyntaxT))]
 pub enum Syntax<'a> {
     /// Root of the parse tree
@@ -549,6 +549,7 @@ impl<'a> PartialEq for StringOrObject<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct ClockData<'a> {
     /// Clock duration for a closed clock, or nil (string or nil).
     duration: &'a str,
@@ -560,21 +561,25 @@ pub struct ClockData<'a> {
     value: TimestampData<'a>,
 }
 
+#[derive(Debug)]
 pub enum ClockStatus {
     Running,
     Closed,
 }
 
+#[derive(Debug)]
 pub struct DiarySexpData<'a> {
     /// Full Sexp (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub enum LineNumberingMode {
     New,
     Continued,
 }
 
+#[derive(Debug)]
 pub struct PlanningData<'a> {
     /// Timestamp associated to closed keyword, if any
     /// (timestamp object or nil).
@@ -591,11 +596,13 @@ pub struct PlanningData<'a> {
 
 // ===== Objects Data ======
 
+#[derive(Debug)]
 pub struct CodeData<'a> {
     /// Contents (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct EntityData<'a> {
     /// Entity's ASCII representation (string).
     ascii: &'a str,
@@ -624,6 +631,7 @@ pub struct EntityData<'a> {
     utf_8: &'a str,
 }
 
+#[derive(Debug)]
 pub struct ExportSnippetData<'a> {
     /// Relative back_end's name (string).
     back_end: &'a str,
@@ -633,6 +641,7 @@ pub struct ExportSnippetData<'a> {
 }
 
 /// Recursive object.
+#[derive(Debug)]
 pub struct FootnoteReferenceData<'a> {
     /// Footnote's label, if any (string or nil).
     label: Option<&'a str>,
@@ -642,6 +651,7 @@ pub struct FootnoteReferenceData<'a> {
     type_s: &'a str,
 }
 
+#[derive(Debug)]
 pub struct InlineBabelCallData<'a> {
     ///Name of code block being called (string).
     call: &'a str,
@@ -659,6 +669,7 @@ pub struct InlineBabelCallData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct InlineSrcBlockData<'a> {
     ///Language of the code in the block (string).
     language: &'a str,
@@ -670,12 +681,14 @@ pub struct InlineSrcBlockData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub enum LinkFormat {
     Plain,
     Angle,
     Bracket,
 }
 
+#[derive(Debug)]
 pub struct LinkData<'a> {
     /// Name of application requested to open the link
     /// in Emacs (string or nil).
@@ -701,6 +714,7 @@ pub struct LinkData<'a> {
     link_type: LinkType,
 }
 
+#[derive(Debug)]
 pub enum LinkType {
     /// Line in some source code,
     Coderef,
@@ -721,6 +735,7 @@ pub enum LinkType {
     Radio,
 }
 
+#[derive(Debug)]
 pub struct MacroData<'a> {
     /// Arguments passed to the macro (list of strings).
     args: Vec<&'a str>,
@@ -732,32 +747,38 @@ pub struct MacroData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct RadioTargetData<'a> {
     /// Uninterpreted contents (string).
     raw_value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct StatisticsCookieData<'a> {
     /// Full cookie (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct SubscriptData {
     /// Non_nil if contents are enclosed in curly brackets (t, nil).
     use_brackets_p: bool,
 }
 
 /// Recursive object.
+#[derive(Debug)]
 pub struct SuperscriptData {
     /// Non_nil if contents are enclosed in curly brackets (t, nil).
     use_brackets_p: bool,
 }
 
+#[derive(Debug)]
 pub struct TargetData<'a> {
     ///Target's ID (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct TimestampData<'a> {
     /// Day part from timestamp end.
     /// If no ending date is defined, it defaults to start day part (integer).
@@ -826,11 +847,13 @@ pub struct TimestampData<'a> {
     year_start: usize,
 }
 
+#[derive(Debug)]
 pub enum WarningType {
     All,
     First,
 }
 
+#[derive(Debug)]
 pub enum TimestampType {
     Active,
     ActiveRange,
@@ -839,12 +862,14 @@ pub enum TimestampType {
     InactiveRange,
 }
 
+#[derive(Debug)]
 pub enum RepeaterType {
     CatchUp,
     Restart,
     Cumulate,
 }
 
+#[derive(Debug)]
 pub enum TimeUnit {
     Year,
     Month,
@@ -853,6 +878,7 @@ pub enum TimeUnit {
     Hour,
 }
 
+#[derive(Debug)]
 pub struct VerbatimData<'a> {
     ///Contents (string).
     value: &'a str,

--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -98,6 +98,13 @@ impl<'a> SyntaxNode<'a> {
             affiliated: None,
         }
     }
+
+    /// Appends a child to the node, setting the child's parent correctly.
+    pub fn append_child(self: Handle<'a>, child: Handle<'a>) {
+        *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
+        self.children.borrow_mut().push(child);
+    }
+    
 }
 
 /// Complete list of syntax entities
@@ -112,6 +119,13 @@ pub enum Syntax<'a> {
 
     /// Greater element
     CenterBlock,
+
+
+
+
+
+
+
 
     /// Element
     Clock(Box<ClockData<'a>>),
@@ -905,5 +919,4 @@ mod test {
         assert!(closure_test(br, |that| bold.can_contain(that)));
         assert!(!closure_test(verse, |that| bold.can_contain(that)));
     }
-
 }

--- a/rust/element/src/drawer.rs
+++ b/rust/element/src/drawer.rs
@@ -27,6 +27,7 @@ lazy_static! {
 
 }
 
+#[derive(Debug)]
 pub struct DrawerData<'a> {
     /// Drawer's name (string).
     pub drawer_name: &'a str,

--- a/rust/element/src/headline.rs
+++ b/rust/element/src/headline.rs
@@ -119,6 +119,7 @@ lazy_static! {
 
 }
 
+#[derive(Debug)]
 pub struct HeadlineData<'a> {
     /// Non_nil if the headline has an archive tag (boolean).
     archivedp: bool,
@@ -168,6 +169,7 @@ pub struct HeadlineData<'a> {
     todo_keyword: TodoKeyword,
 }
 
+#[derive(Debug)]
 pub struct InlineTaskData<'a> {
     /// Inlinetask's CLOSED reference, if any (timestamp object or nil)
     closed: Option<TimestampData<'a>>,
@@ -211,13 +213,16 @@ pub struct InlineTaskData<'a> {
 //
 // In particular, no blank line is allowed between PLANNING and HEADLINE.
 
+#[derive(Debug)]
 pub struct NodePropertyData<'a> {
     key: &'a str,
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct Tag<'a>(&'a str);
 
+#[derive(Debug)]
 pub enum TodoKeyword {
     TODO,
     DONE,

--- a/rust/element/src/keyword.rs
+++ b/rust/element/src/keyword.rs
@@ -25,6 +25,7 @@ lazy_static! {
     pub static ref REGEX_KEYWORD: Regex = Regex::new(r"\+\S+:").unwrap();
 }
 
+#[derive(Debug)]
 pub struct KeywordData<'a> {
     /// Keyword's name (string).
     key: &'a str,

--- a/rust/element/src/latex.rs
+++ b/rust/element/src/latex.rs
@@ -43,6 +43,7 @@ lazy_static! {
 /// In ideal world this should be replaced by a proper parser
 pub static FMTSTR_LATEX_END_ENVIRONMENT: &str = r"\\end{%s}[ \t]*$";
 
+#[derive(Debug)]
 pub struct LatexEnvironmentData<'a> {
     /// Buffer position at first affiliated keyword or
     /// at the beginning of the first line of environment (integer).
@@ -60,6 +61,7 @@ pub struct LatexEnvironmentData<'a> {
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct LatexFragmentData<'a> {
     ///LaTeX code (string).
     value: &'a str,

--- a/rust/element/src/list.rs
+++ b/rust/element/src/list.rs
@@ -109,10 +109,12 @@ lazy_static! {
 /// List structure
 /// This looks like an intermediate list representation, required both by
 /// plain list itself and items in the list.
+#[derive(Debug)]
 pub struct ListStruct {
     // stub
 }
 
+#[derive(Debug)]
 pub struct ItemData<'rope> {
     /// Item's bullet (string).
     bullet: Cow<'rope, str>,
@@ -132,6 +134,7 @@ pub struct ItemData<'rope> {
     structure: ListStruct,
 }
 
+#[derive(Debug)]
 pub struct PlainListData {
     /// Full list's structure, as returned by org_list_struct (alist).
     pub structure: Rc<ListStruct>,
@@ -140,12 +143,14 @@ pub struct PlainListData {
     pub type_s: ListKind,
 }
 
+#[derive(Debug)]
 pub enum ListKind {
     Descriptive,
     Ordered,
     Unordered,
 }
 
+#[derive(Debug)]
 pub enum CheckBox {
     On,
     Off,

--- a/rust/element/src/markup.rs
+++ b/rust/element/src/markup.rs
@@ -34,17 +34,20 @@ lazy_static! {
 
 }
 
+#[derive(Debug)]
 pub struct CommentData<'a> {
     /// Comments, with pound signs (string).
     value: &'a str,
 }
 
+#[derive(Debug)]
 pub struct FixedWidthData<'a> {
     ///Contents, without colons prefix (string).
     value: &'a str,
 }
 
 /// Greater element
+#[derive(Debug)]
 pub struct FootnoteDefinitionData<'a> {
     /// Label used for references (string).
     label: &'a str,

--- a/rust/element/src/table.rs
+++ b/rust/element/src/table.rs
@@ -26,6 +26,7 @@ lazy_static! {
     pub static ref REGEX_TABLE_PRE_BORDER: Regex = Regex::new(r"^[ \t]*($|[^|])").unwrap();
 }
 
+#[derive(Debug)]
 pub struct TableData<'a> {
     /// Formulas associated to the table, if any (string or nil).
     tblfm: Option<&'a str>,
@@ -36,11 +37,13 @@ pub struct TableData<'a> {
     // value
 }
 
+#[derive(Debug)]
 pub struct TableRowData {
     table_row_type: TableRowType,
 }
 
 /// Row's type (symbol standard, rule).
+#[derive(Debug)]
 pub enum TableRowType {
     Standard,
     Rule,


### PR DESCRIPTION
Iterator to iterate over the children (and itself) of a `SyntaxNode`. This is
used, along with other Rust iterator methods, to replace lisp functions such
as `org-element-map`.

Depends on #45 and #46. 