### PR TITLE
Make `Parser::parse_buffer` pub

### DIFF
--- a/rust/element/src/parser.rs
+++ b/rust/element/src/parser.rs
@@ -128,7 +128,7 @@ impl<'a> Parser<'a> {
 
     /// org-element-parse-buffer
     /// Parses input from beginning to the end
-    fn parse_buffer(&'a self) -> SyntaxNode {
+    pub fn parse_buffer(&'a self) -> SyntaxNode {
         self.cursor.borrow_mut().set(0);
         self.cursor.borrow_mut().skip_whitespace();
 


### PR DESCRIPTION
This is the main entrypoint to the parser, and so must be pub