### PR TITLE
Add `Environment`

### DIFF
--- a/rust/element/src/affiliated.rs
+++ b/rust/element/src/affiliated.rs
@@ -146,7 +146,7 @@ impl<'a> Default for AffiliatedData<'a> {
     }
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     /// Collect affiliated keywords from point down to LIMIT.
     ///
     /// Most elements can have affiliated keywords.  When looking for an
@@ -268,6 +268,7 @@ mod test {
     use crate::cursor::{is_multiline_regex, Cursor};
     use crate::data::RepeaterType::CatchUp;
     use crate::data::StringOrObject;
+    use crate::environment::DefaultEnvironment;
     use crate::parser::ParseGranularity;
     use crate::parser::Parser;
     use regex::Match;
@@ -350,7 +351,7 @@ mod test {
         text.push_str(r"#+attr_html: :file filename.ext");
         text.push_str("\n\n");
         {
-            let p = Parser::new(text.as_str(), ParseGranularity::Object);
+            let p = Parser::new(text.as_str(), ParseGranularity::Object, DefaultEnvironment);
             let maybe_collected = p.collect_affiliated_keywords(text.len());
             assert_eq!(0, maybe_collected.0);
             assert!(maybe_collected.1.is_none());
@@ -358,7 +359,7 @@ mod test {
         text.pop();
         text.push_str("#+BEGIN_SRC");
 
-        let p = Parser::new(text.as_str(), ParseGranularity::Object);
+        let p = Parser::new(text.as_str(), ParseGranularity::Object, DefaultEnvironment);
         let maybe_collected = p.collect_affiliated_keywords(text.len());
         assert_eq!(0, maybe_collected.0);
         assert!(maybe_collected.1.is_some());

--- a/rust/element/src/babel.rs
+++ b/rust/element/src/babel.rs
@@ -39,7 +39,7 @@ pub struct BabelCallData<'a> {
     pub value: &'a str,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement babel_call_parser
     pub fn babel_call_parser(
         &self,

--- a/rust/element/src/blocks.rs
+++ b/rust/element/src/blocks.rs
@@ -138,7 +138,7 @@ pub struct SrcBlockData<'a> {
     value: &'a str,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement center_block_parser
     pub fn center_block_parser(
         &self,

--- a/rust/element/src/drawer.rs
+++ b/rust/element/src/drawer.rs
@@ -32,7 +32,7 @@ pub struct DrawerData<'a> {
     pub drawer_name: &'a str,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement drawer_parser
     pub fn drawer_parser(
         &self,

--- a/rust/element/src/environment.rs
+++ b/rust/element/src/environment.rs
@@ -1,0 +1,6 @@
+/// The environment should hold the configration options that org uses.
+pub trait Environment {}
+
+pub struct DefaultEnvironment;
+
+impl Environment for DefaultEnvironment {}

--- a/rust/element/src/headline.rs
+++ b/rust/element/src/headline.rs
@@ -223,7 +223,7 @@ pub enum TodoKeyword {
     DONE,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement headline_parser
     pub fn headline_parser(&self) -> SyntaxNode<'a> {
         unimplemented!()

--- a/rust/element/src/keyword.rs
+++ b/rust/element/src/keyword.rs
@@ -32,7 +32,7 @@ pub struct KeywordData<'a> {
     value: &'a str,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement keyword_parser
     /// Parse a keyword at point.
     ///

--- a/rust/element/src/latex.rs
+++ b/rust/element/src/latex.rs
@@ -65,7 +65,7 @@ pub struct LatexFragmentData<'a> {
     value: &'a str,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement latext_environment_parser
     /// Parse a LaTeX environment.
     /// LIMIT bounds the search.  AFFILIATED is a list of which CAR is

--- a/rust/element/src/lib.rs
+++ b/rust/element/src/lib.rs
@@ -34,6 +34,7 @@ mod blocks;
 mod cursor;
 mod data;
 mod drawer;
+mod environment;
 mod fixed_width;
 mod headline;
 mod keyword;

--- a/rust/element/src/list.rs
+++ b/rust/element/src/list.rs
@@ -152,7 +152,7 @@ pub enum CheckBox {
     Trans,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement item_parser
     //https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-element.el#L1253
     pub fn item_parser(

--- a/rust/element/src/markup.rs
+++ b/rust/element/src/markup.rs
@@ -55,7 +55,7 @@ pub struct FootnoteDefinitionData<'a> {
     pre_blank: u8,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement comment_parser
     pub fn comment_parser(
         &self,

--- a/rust/element/src/paragraph.rs
+++ b/rust/element/src/paragraph.rs
@@ -30,7 +30,7 @@ use crate::parser::Parser;
 ///
 /// Assume point is at the beginning of the paragraph."
 /// (defun org-element-paragraph-parser (limit affiliated)
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement paragraph_parser
     pub fn paragraph_parser(
         &self,

--- a/rust/element/src/planning.rs
+++ b/rust/element/src/planning.rs
@@ -22,7 +22,7 @@ lazy_static! {
     pub static ref REGEX_DIARY_SEXP: Regex = Regex::new(r"%%\(").unwrap();
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement planning_parser
     pub fn planning_parser(&self, limit: usize) -> SyntaxNode<'a> {
         unimplemented!()

--- a/rust/element/src/table.rs
+++ b/rust/element/src/table.rs
@@ -46,7 +46,7 @@ pub enum TableRowType {
     Rule,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     // TODO implement table_row_parser
     // https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-element.el#L2637
     pub fn table_row_parser(&self) -> SyntaxNode<'a> {


### PR DESCRIPTION
Environment enables org-rs to handle customization options. Many aspects of the
behavior of org are controlled by variables the user is meant to set, including
 parts of org-element.