### PR TITLE
Add `SyntaxNode::create_raw_at` for elisp strings

### DIFF
--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -98,6 +98,20 @@ impl<'a> SyntaxNode<'a> {
             affiliated: None,
         }
     }
+
+    /// Creates a `SyntaxNode` corosponding to a raw string used as an element
+    /// in elisp.
+    pub fn create_raw_at(content: &'a str, interval: Interval) -> SyntaxNode<'a> {
+        SyntaxNode {
+            parent: RefCell::new(None),
+            children: RefCell::new(vec![]),
+            data: Syntax::PlainText(string),
+            location: interval,
+            content_location: None,
+            post_blank: 0,
+            afiliated: None,
+        }
+    }
 }
 
 /// Complete list of syntax entities


### PR DESCRIPTION
Sometimes strings are used in the elisp as though they are syntax nodes. Instead, since the elsip uses the string properties that are a part of elisp, we use the `plain-text` type directly.