### PR TITLE
[refactor]: Idiomatic formatting and Rust conventions

### DIFF
--- a/rust/element/src/data.rs
+++ b/rust/element/src/data.rs
@@ -40,12 +40,6 @@ use std::{
 
 use regex::Regex;
 
-/// Reference to a DOM node.
-pub type Handle<'a> = Rc<SyntaxNode<'a>>;
-
-/// Weak reference to a DOM node, used for parent pointers.
-pub type WeakHandle<'a> = Weak<SyntaxNode<'a>>;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Interval {
     pub start: usize,
@@ -61,9 +55,9 @@ pub struct AffiliatedKeywords;
 #[derive(Debug)]
 pub struct SyntaxNode<'a> {
     /// Parent node.
-    pub parent: RefCell<Option<WeakHandle<'a>>>,
+    pub parent: RefCell<Option<Weak<SyntaxNode<'a>>>>,
     /// Child nodes of this node.
-    pub children: RefCell<Vec<Handle<'a>>>,
+    pub children: RefCell<Vec<Rc<SyntaxNode<'a>>>>,
 
     pub data: Syntax<'a>,
 
@@ -99,7 +93,7 @@ impl<'a> SyntaxNode<'a> {
 
     /// Creates an iterator over the node and its direct and indirect
     /// children, in pre-order.
-    pub fn nodes(self: &Handle<'a>) -> Nodes<'a> {
+    pub fn nodes(self: &Rc<SyntaxNode<'a>>) -> Nodes<'a> {
         Nodes::new(self.clone())
     }
 
@@ -118,17 +112,18 @@ impl<'a> SyntaxNode<'a> {
     }
 
     /// Appends a child to the node, setting the child's parent correctly.
-    pub fn append_child(self: &Handle<'a>, child: Handle<'a>) {
+    pub fn append_child(self: &Rc<SyntaxNode<'a>>, child: Rc<SyntaxNode<'a>>) {
         *child.parent.borrow_mut() = Some(Rc::downgrade(&self));
         self.children.borrow_mut().push(child);
     }
 }
 
-/// Complete list of syntax entities
+/// An enumerated list of all Org syntactic units.
+/// This structure is not meant to be extended.
 #[derive(Debug, EnumDiscriminants)]
 #[strum_discriminants(name(SyntaxT))]
 pub enum Syntax<'a> {
-    /// Root of the parse tree
+    /// The root of the parse tree
     OrgData,
 
     /// Element
@@ -187,7 +182,6 @@ pub enum Syntax<'a> {
     Item(Box<ItemData<'a>>),
 
     /// Element
-    /// <br>
     /// Keywords follow the syntax:
     /// ```org
     ///   #+KEY: VALUE
@@ -197,7 +191,8 @@ pub enum Syntax<'a> {
     /// If KEY belongs to org-element-document-properties, VALUE can contain objects.
     Keyword(Box<KeywordData<'a>>),
 
-    ///Element
+    /// Element
+    /// An inline Latex environment element
     LatexEnvironment(Box<LatexEnvironmentData<'a>>),
 
     /// Element
@@ -307,134 +302,55 @@ pub enum Syntax<'a> {
 }
 
 impl SyntaxT {
-    #[rustfmt::skip]
     pub fn is_greater_element(self) -> bool {
         use SyntaxT::*;
         match self {
-            CenterBlock        => true,   // Greater element
-            Drawer             => true,   // Greater element
-            DynamicBlock       => true,   // Greater element
-            FootnoteDefinition => true,   // Greater element
-            Headline           => true,   // Greater element
-            InlineTask         => true,   // Greater element
-            Item               => true,   // Greater element
-            PlainList          => true,   // Greater element
-            PropertyDrawer     => true,   // Greater element
-            QuoteBlock         => true,   // Greater element
-            Section            => true,   // Greater element
-            SpecialBlock       => true,   // Greater element
-            Table              => true,   // Greater element
-            _                  => false
-
+            CenterBlock | Drawer | DynamicBlock | FootnoteDefinition | Headline | InlineTask
+            | Item | PlainList | PropertyDrawer | QuoteBlock | Section | SpecialBlock | Table => {
+                true
+            }
+            _ => false,
         }
     }
 
-    #[rustfmt::skip]
     fn is_element(self) -> bool {
         use SyntaxT::*;
         match self {
-            BabelCall          => true,   // Element
-            CenterBlock        => true,   // Greater element
-            Clock              => true,   // Element
-            Comment            => true,   // Element
-            CommentBlock       => true,   // Element
-            DiarySexp          => true,   // Element
-            Drawer             => true,   // Greater element
-            DynamicBlock       => true,   // Greater element
-            ExampleBlock       => true,   // Element
-            ExportBlock        => true,   // Element
-            FixedWidth         => true,   // Element
-            FootnoteDefinition => true,   // Greater element
-            Headline           => true,   // Greater element
-            HorizontalRule     => true,   // Element
-            InlineTask         => true,   // Greater element
-            Item               => true,   // Greater element
-            Keyword            => true,   // Element
-            LatexEnvironment   => true,   // Element
-            NodeProperty       => true,   // Element
-            Paragraph          => true,   // Element containing objects.
-            PlainList          => true,   // Greater element
-            Planning           => true,   // Element
-            PropertyDrawer     => true,   // Greater element
-            QuoteBlock         => true,   // Greater element
-            Section            => true,   // Greater element
-            SpecialBlock       => true,   // Greater element
-            SrcBlock           => true,   // Element
-            Table              => true,   // Greater element
-            TableRow           => true,   // Element containing objects.
-            VerseBlock         => true,   // Element containing objects.
-            _                  => false
-
+            BabelCall | CenterBlock | Clock | Comment | CommentBlock | DiarySexp | Drawer
+            | DynamicBlock | ExampleBlock | ExportBlock | FixedWidth | FootnoteDefinition
+            | Headline | HorizontalRule | InlineTask | Item | Keyword | LatexEnvironment
+            | NodeProperty | Paragraph | PlainList | Planning | PropertyDrawer | QuoteBlock
+            | Section | SpecialBlock | SrcBlock | Table | TableRow | VerseBlock => true,
+            _ => false,
         }
     }
 
-    #[rustfmt::skip]
     fn is_object(self) -> bool {
         use SyntaxT::*;
         match self {
-            Bold              => true,  // Recursive object
-            Code              => true,  // Object.
-            Entity            => true,  // Object
-            ExportSnippet     => true,  // Object
-            FootnoteReference => true,  // Recursive object.
-            InlineBabelCall   => true,  // Object
-            InlineSrcBlock    => true,  // Object
-            Italic            => true,  // Recursive object.
-            LineBreak         => true,  // Object
-            LatexFragment     => true,  // Object
-            Link              => true,  // Recursive object.
-            Macro             => true,  // Object
-            RadioTarget       => true,  // Recursive object.
-            StatisticsCookie  => true,  // Object
-            StrikeThrough     => true,  // Recursive object.
-            Subscript         => true,  // Recursive object.
-            Superscript       => true,  // Recursive object.
-            TableCell         => true,  // Recursive object
-            Target            => true,  // Object
-            Timestamp         => true,  // Object
-            Underline         => true,  // Recursive object.
-            Verbatim          => true,  // Object
-            PlainText         => true,  // Special object
-            _                 => false
+            Bold | Code | Entity | ExportSnippet | FootnoteReference | InlineBabelCall
+            | InlineSrcBlock | Italic | LineBreak | LatexFragment | Link | Macro | RadioTarget
+            | StatisticsCookie | StrikeThrough | Subscript | Superscript | TableCell | Target
+            | Timestamp | Underline | Verbatim | PlainText => true,
+            _ => false,
         }
     }
 
-    #[rustfmt::skip]
     fn is_recursive_object(self) -> bool {
         use SyntaxT::*;
         match self {
-            Bold              => true,  // Recursive object
-            FootnoteReference => true,  // Recursive object.
-            Italic            => true,  // Recursive object.
-            Link              => true,  // Recursive object.
-            RadioTarget       => true,  // Recursive object.
-            StrikeThrough     => true,  // Recursive object.
-            Subscript         => true,  // Recursive object.
-            Superscript       => true,  // Recursive object.
-            TableCell         => true,  // Recursive object
-            Underline         => true,  // Recursive object.
-            _                 => false
+            Bold | FootnoteReference | Italic | Link | RadioTarget | StrikeThrough | Subscript
+            | Superscript | TableCell | Underline => true,
+            _ => false,
         }
     }
 
-    #[rustfmt::skip]
     fn is_object_container(self) -> bool {
         use SyntaxT::*;
         match self {
-            Paragraph         => true,  // Element containing objects.
-            TableRow          => true,  // Element containing objects.
-            VerseBlock        => true,  // Element containing objects.
-            Bold              => true,  // Recursive object
-            FootnoteReference => true,  // Recursive object.
-            Italic            => true,  // Recursive object.
-            Link              => true,  // Recursive object.
-            RadioTarget       => true,  // Recursive object.
-            StrikeThrough     => true,  // Recursive object.
-            Subscript         => true,  // Recursive object.
-            Superscript       => true,  // Recursive object.
-            TableCell         => true,  // Recursive object
-            Underline         => true,  // Recursive object.
-            _                 => false
+            Paragraph | TableRow | VerseBlock | Bold | FootnoteReference | Italic | Link
+            | RadioTarget | StrikeThrough | Subscript | Superscript | TableCell | Underline => true,
+            _ => false,
         }
     }
 
@@ -617,8 +533,6 @@ pub struct PlanningData<'a> {
     /// (timestamp object or nil).
     scheduled: Option<TimestampData<'a>>,
 }
-
-// ===== Objects Data ======
 
 #[derive(Debug)]
 pub struct CodeData<'a> {
@@ -911,11 +825,11 @@ pub struct VerbatimData<'a> {
 /// A pre-order traversal of a [`SyntaxNode`].
 pub struct Nodes<'a> {
     index_stack: Vec<usize>,
-    current_node: Handle<'a>,
+    current_node: Rc<SyntaxNode<'a>>,
 }
 
 impl<'a> Nodes<'a> {
-    fn new(handle: Handle<'a>) -> Nodes<'a> {
+    fn new(handle: Rc<SyntaxNode<'a>>) -> Nodes<'a> {
         Nodes {
             index_stack: vec![0],
             current_node: handle,
@@ -924,9 +838,9 @@ impl<'a> Nodes<'a> {
 }
 
 impl<'a> Iterator for Nodes<'a> {
-    type Item = Handle<'a>;
+    type Item = Rc<SyntaxNode<'a>>;
 
-    fn next(&mut self) -> Option<Handle<'a>> {
+    fn next(&mut self) -> Option<Rc<SyntaxNode<'a>>> {
         dbg!(&self.index_stack);
         let node = self.current_node.clone();
 

--- a/rust/element/src/parser.rs
+++ b/rust/element/src/parser.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 
 use crate::babel::REGEX_BABEL_CALL;
 use crate::cursor::Cursor;
-use crate::data::{Handle, Syntax, SyntaxNode, SyntaxT};
+use crate::data::{Syntax, SyntaxNode, SyntaxT};
 use crate::environment::Environment;
 
 use crate::blocks::{
@@ -55,6 +55,7 @@ pub enum ParseGranularity {
 }
 
 /// MODE prioritizes some elements over the others
+///
 /// @ngortheone - it looks like these are states of parser's finite automata
 #[derive(Copy, Clone, PartialEq)]
 pub enum ParserMode {
@@ -107,27 +108,26 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
     /// <br>
     /// Original function name: org-element--next-mode
     /// https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-element.el#L4273
-    #[rustfmt::skip]
     fn next_mode(syntax: SyntaxT, is_parent: bool) -> Option<ParserMode> {
         use SyntaxT::*;
 
         if is_parent {
             match syntax {
-                Headline      => Some(ParserMode::Section),
-                InlineTask    => Some(ParserMode::Planning),
-                PlainList     => Some(ParserMode::Item),
-                PropertyDrawer=> Some(ParserMode::NodeProperty),
-                Section       => Some(ParserMode::Planning),
-                Table         => Some(ParserMode::TableRow),
-                _             => None,
+                Headline => Some(ParserMode::Section),
+                InlineTask => Some(ParserMode::Planning),
+                PlainList => Some(ParserMode::Item),
+                PropertyDrawer => Some(ParserMode::NodeProperty),
+                Section => Some(ParserMode::Planning),
+                Table => Some(ParserMode::TableRow),
+                _ => None,
             }
         } else {
             match syntax {
-                Item         => Some(ParserMode::Item),
+                Item => Some(ParserMode::Item),
                 NodeProperty => Some(ParserMode::NodeProperty),
-                Planning     => Some(ParserMode::PropertyDrawer),
-                TableRow     => Some(ParserMode::TableRow),
-                _            => None,
+                Planning => Some(ParserMode::PropertyDrawer),
+                TableRow => Some(ParserMode::TableRow),
+                _ => None,
             }
         }
     }
@@ -164,7 +164,7 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
         end: usize,
         mut mode: ParserMode,
         structure: Option<Rc<ListStruct>>,
-    ) -> Vec<Handle> {
+    ) -> Vec<Rc<SyntaxNode>> {
         let pos = self.cursor.borrow_mut().pos();
         self.cursor.borrow_mut().set(beg);
 
@@ -174,7 +174,7 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
             self.cursor.borrow_mut().next_headline();
         }
 
-        let mut elements: Vec<Handle> = vec![];
+        let mut elements: Vec<Rc<SyntaxNode>> = vec![];
         loop {
             let current_pos = self.cursor.borrow().pos();
             if current_pos >= end {
@@ -365,11 +365,11 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
             }
 
             // From there, elements can have affiliated keywords.
-            let (aff_start, maybe_aff) = self.collect_affiliated_keywords(limit);
+            let (aff_start, affiliated) = self.collect_affiliated_keywords(limit);
 
             // If parsing affiliated keywords left cursor off-limits
             // then parse them as regular keywords.
-            if (maybe_aff.is_some() && self.cursor.borrow().pos() >= limit) {
+            if (affiliated.is_some() && self.cursor.borrow().pos() >= limit) {
                 self.cursor.borrow_mut().set(aff_start);
                 return self.keyword_parser(limit, aff_start, None);
             }
@@ -377,17 +377,17 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
             // LaTeX Environment
             //org-element--latex-begin-environment
             if looking_at!(REGEX_LATEX_BEGIN_ENVIRIONMENT, self).is_some() {
-                return self.latex_environment_parser(limit, aff_start, maybe_aff);
+                return self.latex_environment_parser(limit, aff_start, affiliated);
             }
 
             // Drawer and Property Drawer.
             if looking_at!(REGEX_DRAWER, self).is_some() {
-                return self.drawer_parser(limit, aff_start, maybe_aff);
+                return self.drawer_parser(limit, aff_start, affiliated);
             }
 
             //  Fixed Width
             if looking_at!(REGEX_FIXED_WIDTH, self).is_some() {
-                return self.fixed_width_parser(limit, aff_start, maybe_aff);
+                return self.fixed_width_parser(limit, aff_start, affiliated);
             }
 
             // Inline Comments, Blocks, Babel Calls, Dynamic Blocks and Keywords.
@@ -395,63 +395,67 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
                 self.cursor.borrow_mut().set(m.end());
                 if looking_at!(REGEX_COLON_OR_EOL, self).is_some() {
                     self.cursor.borrow_mut().goto_line_begin();
-                    return self.comment_parser(limit, aff_start, maybe_aff);
+                    return self.comment_parser(limit, aff_start, affiliated);
                 }
 
                 if let Some(cap) = capturing_at!(REGEX_BLOCK_BEGIN, self) {
                     self.cursor.borrow_mut().goto_line_begin();
                     let name = cap.get(1).unwrap().as_str().to_owned().to_ascii_uppercase();
                     match name.as_ref() {
-                        "CENTER" => return self.center_block_parser(limit, aff_start, maybe_aff),
-                        "COMMENT" => return self.comment_block_parser(limit, aff_start, maybe_aff),
-                        "EXAMPLE" => return self.example_block_parser(limit, aff_start, maybe_aff),
-                        "EXPORT" => return self.export_block_parser(limit, aff_start, maybe_aff),
-                        "QUOTE" => return self.quote_block_parser(limit, aff_start, maybe_aff),
-                        "SRC" => return self.src_block_parser(limit, aff_start, maybe_aff),
-                        "VERSE" => return self.verse_block_parser(limit, aff_start, maybe_aff),
-                        _ => return self.special_block_parser(limit, aff_start, maybe_aff),
+                        "CENTER" => return self.center_block_parser(limit, aff_start, affiliated),
+                        "COMMENT" => {
+                            return self.comment_block_parser(limit, aff_start, affiliated)
+                        }
+                        "EXAMPLE" => {
+                            return self.example_block_parser(limit, aff_start, affiliated)
+                        }
+                        "EXPORT" => return self.export_block_parser(limit, aff_start, affiliated),
+                        "QUOTE" => return self.quote_block_parser(limit, aff_start, affiliated),
+                        "SRC" => return self.src_block_parser(limit, aff_start, affiliated),
+                        "VERSE" => return self.verse_block_parser(limit, aff_start, affiliated),
+                        _ => return self.special_block_parser(limit, aff_start, affiliated),
                     }
                 }
 
                 if looking_at!(REGEX_BABEL_CALL, self).is_some() {
                     self.cursor.borrow_mut().goto_line_begin();
-                    return self.babel_call_parser(limit, aff_start, maybe_aff);
+                    return self.babel_call_parser(limit, aff_start, affiliated);
                 }
 
                 if looking_at!(REGEX_DYNAMIC_BLOCK, self).is_some() {
                     self.cursor.borrow_mut().goto_line_begin();
-                    return self.dynamic_block_parser(limit, aff_start, maybe_aff);
+                    return self.dynamic_block_parser(limit, aff_start, affiliated);
                 }
 
                 if looking_at!(REGEX_KEYWORD, self).is_some() {
                     self.cursor.borrow_mut().goto_line_begin();
-                    return self.keyword_parser(limit, aff_start, maybe_aff);
+                    return self.keyword_parser(limit, aff_start, affiliated);
                 }
 
                 // If none of the above fits then this is just a paragraph
                 self.cursor.borrow_mut().goto_line_begin();
-                return self.paragraph_parser(limit, aff_start, maybe_aff);
+                return self.paragraph_parser(limit, aff_start, affiliated);
             }
 
             // Footnote Definition
             if looking_at!(REGEX_FOOTNOTE_DEFINITION, self).is_some() {
-                return self.footnote_definition_parser(limit, aff_start, maybe_aff);
+                return self.footnote_definition_parser(limit, aff_start, affiliated);
             }
 
             //  Horizontal Rule.
             if looking_at!(REGEX_HORIZONTAL_RULE, self).is_some() {
-                return self.horizontal_rule_parser(limit, aff_start, maybe_aff);
+                return self.horizontal_rule_parser(limit, aff_start, affiliated);
             }
 
             // Diary Sexp.
             if looking_at!(REGEX_DIARY_SEXP, self).is_some() {
-                return self.diary_sexp_parser(limit, aff_start, maybe_aff);
+                return self.diary_sexp_parser(limit, aff_start, affiliated);
             }
 
             // Table
             // NB: table.el style tables are not supported
             if looking_at!(REGEX_TABLE_BORDER, self).is_some() {
-                return self.table_parser(limit, aff_start, maybe_aff);
+                return self.table_parser(limit, aff_start, affiliated);
             }
 
             // List.
@@ -461,11 +465,11 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
             //    (or structure (org-element--list-struct limit))))
             if looking_at!(REGEX_ITEM, self).is_some() {
                 let s = structure.unwrap_or(self.list_struct(limit));
-                return self.plain_list_parser(limit, aff_start, maybe_aff, s.clone());
+                return self.plain_list_parser(limit, aff_start, affiliated, s.clone());
             }
 
             // Default element: Paragraph.
-            return self.paragraph_parser(limit, aff_start, maybe_aff);
+            return self.paragraph_parser(limit, aff_start, affiliated);
         };
 
         let current_element = get_current_element();
@@ -490,11 +494,8 @@ impl<'a, Environment: crate::environment::Environment> Parser<'a, Environment> {
         beg: usize,
         end: usize,
         restriction: impl Fn(SyntaxT) -> bool,
-    ) -> Vec<Handle> //acc
+    ) -> Vec<Rc<SyntaxNode>> //acc
     {
-        let pos = self.cursor.borrow().pos();
-        // TODO write parse_objects function #8
-        self.cursor.borrow_mut().set(pos);
-        unimplemented!();
+        todo!("#8")
     }
 }


### PR DESCRIPTION
This is a slight shift in the style of the library. While it is to be understood that some things that require adherence to Emacs lisp conventions are more conveniently expressed as similar to Emacs lisp, other things have few if any reasons **not** to be formatted idiomatically. 